### PR TITLE
fix issue #7

### DIFF
--- a/_mappy-breakpoints.scss
+++ b/_mappy-breakpoints.scss
@@ -80,7 +80,7 @@ $mappy-queries: () !default;
   }
   $_return: (
     type: $type,
-    media-string: inspect($media-string),
+    media-string: implode($media-string),
     query-fallback: $query-fallback
   );
 
@@ -234,4 +234,24 @@ $mappy-queries: () !default;
 
 @function mappy-strip-unit($num) {
   @return $num / ($num * 0 + 1);
+}
+
+// Implode [Function]
+// --------------------
+// Implode a list into a string
+@function implode($list, $glue: ' ') {
+  $res: null;
+  $len: length($list);
+
+  @for $i from 1 through $len {
+    $e: nth($list, $i);
+    @if $i == $len {
+      $res: $res#{$e};
+    }
+    @else {
+      $res: $res#{$e}#{$glue};
+    }
+  }
+
+  @return $res;
 }

--- a/test/_media-strings.scss
+++ b/test/_media-strings.scss
@@ -1,4 +1,3 @@
-
 // Test Media Strings
 @include test-module('Media Queries') {
   @include test('should use $breakpoints map') {
@@ -41,5 +40,12 @@
     $media-string: map-get($mappy-map, media-string);
 
     @include assert-equal($media-string, unquote("(orientation: portrait)"))
+  }
+
+  @include test('should output min-width queries with only one param') {
+    $mappy-map: mappy-bp(100em);
+    $media-string: map-get($mappy-map, media-string);
+
+    @include assert-equal($media-string, unquote("(min-width: 100em)"))
   }
 }


### PR DESCRIPTION
When only a value is passed to function `mappy-bp`, `inspect` (libass >= 3.3.3) will append an extra comma at the end, breaking the media query.
Using `implode` is the correct way of doing it.

Please note that the current testcase can't detect this error because `sass-true` internally use `node-sass@3.4.0` at the moment, which in turn use `libsass < 3.3.3`. That's said, the test suite is ok to ensure back compatibility.

I've done another pull request because the previous one had some bad commits in it, better to have a clean history. Before I've been deceived by the `join` function, thinking it will return a string, but instead it concatenate two list! Therefore I've included an `implode` function to have no surprise.
