### PR TITLE
Quoting interpolation

### DIFF
--- a/_mappy-breakpoints.scss
+++ b/_mappy-breakpoints.scss
@@ -246,10 +246,10 @@ $mappy-queries: () !default;
   @for $i from 1 through $len {
     $e: nth($list, $i);
     @if $i == $len {
-      $res: $res#{$e};
+      $res: unquote("#{$res}#{$e}");
     }
     @else {
-      $res: $res#{$e}#{$glue};
+      $res: unquote("#{$res}#{$e}#{$glue}");
     }
   }
 


### PR DESCRIPTION
Fixing this warning:
DEPRECATION WARNING: interpolation near operators will be simplified in a future version of Sass. To preserve the current behavior, use quotes.
