### PR TITLE
docs(readme): fix scss code block syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If a two values are provided, mappy-breakpoints will produce a `min-width` and `
 
 If a `max-width` or `max` string is provided, `mappy-breakpoints()` will produce a `max-width` query.
 
-~~~
+~~~scss
 // Max Width Query
 // ---------------
 
@@ -190,6 +190,7 @@ It can use the same `$breakpoints` map as well.
 
 If a `max-height` or `max` string is provided, `mappy-breakpoints()` will produce a `max-height` query.
 
+~~~scss
 // Max Height Query
 // ---------------
 


### PR DESCRIPTION
Hey there, I noticed that two of the scss code blocks in the readme weren't showing the right syntax highlighting. 

It looks like the issue is that  one block needs a language declaration, and the other block needs to be initialized.

I went ahead and proposed this change to fix both blocks -- thank you!